### PR TITLE
Update 2021-01-29-lecture01.md

### DIFF
--- a/_posts/2021-01-29-lecture01.md
+++ b/_posts/2021-01-29-lecture01.md
@@ -141,7 +141,7 @@ where $w \in \mathbb{R}^d$ is a vector containing all the regression coefficient
 The second step is the loss function. Let us define the MSE loss in this case:
 
 $$
-L(w) = \frac{1}{2} \sum_{i=1}^d (y_i - \langle x, w \rangle)^2,
+L(w) = \frac{1}{2} \sum_{i=1}^n (y_i - \langle x_i, w \rangle)^2,
 $$
 
 For conciseness, we write this as:


### PR DESCRIPTION
Upper bound to sum in definition of MSE loss changed from d to n. x changed to x_i in the same equation.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->